### PR TITLE
Switch to bitnami kafka image in cicd

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,10 +20,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - run: |
-          wget -O ./kafka.docker-compose.yml https://raw.githubusercontent.com/rinkudesu/kafka-docker/main/docker-compose.yml
-          docker compose -f kafka.docker-compose.yml up -d
       - uses: actions/checkout@v3
+      - run: |
+          docker compose -f test-kafka.docker-compose.yml up -d
       - uses: actions/setup-go@v3
         with:
           go-version: '>=1.17.0'
@@ -33,12 +32,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - run: |
-          wget -O ./kafka.docker-compose.yml https://raw.githubusercontent.com/rinkudesu/kafka-docker/main/docker-compose.yml
-          docker compose -f kafka.docker-compose.yml up -d
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - run: |
+          docker compose -f test-kafka.docker-compose.yml up -d
       - uses: actions/setup-go@v3
         with:
           go-version: '>=1.17.0'

--- a/test-kafka.docker-compose.yml
+++ b/test-kafka.docker-compose.yml
@@ -1,0 +1,19 @@
+version: "2"
+
+services:
+  zookeeper:
+    image: docker.io/bitnami/zookeeper
+    environment:
+      - ALLOW_ANONYMOUS_LOGIN=yes
+      - KAFKA_TLS_CLIENT_AUTH=none
+  kafka:
+    image: docker.io/bitnami/kafka
+    ports:
+      - "127.0.0.1:9092:9092"
+    environment:
+      - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181
+      - ALLOW_PLAINTEXT_LISTENER=yes
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092
+      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://127.0.0.1:9092
+    depends_on:
+      - zookeeper


### PR DESCRIPTION
Closes #9 in comliance with kafka-docker deprecation.